### PR TITLE
Debian packaging (.deb) + self-hosted APT repo

### DIFF
--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -1,0 +1,44 @@
+name: Build .deb
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  deb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb --locked
+
+      - name: Build .deb
+        run: cargo deb
+
+      - name: Show package contents
+        run: |
+          set -e
+          deb=$(ls target/debian/*.deb | head -1)
+          echo "Built: $deb"
+          dpkg-deb --info "$deb"
+          dpkg-deb --contents "$deb"
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qssh-deb
+          path: target/debian/*.deb
+
+      - name: Attach .deb to GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/debian/*.deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,3 +149,47 @@ hybrid-kex = ["x25519-dalek"] # X25519+ML-KEM hybrid key exchange
 
 [[example]]
 name = "quantum_harmony_validator"
+
+# ----------------------------------------------------------------------------
+# Debian package (.deb) — built with cargo-deb (`cargo install cargo-deb`).
+# Build on a Linux host (or a Linux cross target): `cargo deb`.
+# See docs/PACKAGING.md for details.
+# ----------------------------------------------------------------------------
+[package.metadata.deb]
+maintainer = "Paraxiom <sylvain@paraxiom.org>"
+copyright = "2026, Paraxiom. Dual-licensed MIT OR Apache-2.0."
+license-file = ["LICENSE-MIT", "0"]
+section = "net"
+priority = "optional"
+depends = "$auto"
+extended-description = """
+QSSH is a post-quantum secure shell: an SSH-style client/server suite using
+NIST PQC algorithms (Falcon / FN-DSA, SPHINCS+ / SLH-DSA, ML-KEM) with
+configurable security tiers and a quantum-resistant protocol design.
+
+This package installs the qsshd daemon, the qssh client and the supporting
+tools (qscp, qssh-keygen, qssh-passwd, qssh-agent, qssh-sign, qssh-add,
+qssh-node), plus a systemd service for qsshd.
+"""
+assets = [
+    ["target/release/qssh",        "usr/bin/", "755"],
+    ["target/release/qsshd",       "usr/bin/", "755"],
+    ["target/release/qscp",        "usr/bin/", "755"],
+    ["target/release/qssh-keygen", "usr/bin/", "755"],
+    ["target/release/qssh-passwd", "usr/bin/", "755"],
+    ["target/release/qssh-agent",  "usr/bin/", "755"],
+    ["target/release/qssh-sign",   "usr/bin/", "755"],
+    ["target/release/qssh-add",    "usr/bin/", "755"],
+    ["target/release/qssh-node",   "usr/bin/", "755"],
+    ["qsshd.config.production",    "etc/qssh/qsshd.config", "644"],
+    ["packaging/qsshd.env",        "etc/qssh/qsshd.env",    "644"],
+    ["README.md",                  "usr/share/doc/qssh/README.md",   "644"],
+    ["docs/PACKAGING.md",          "usr/share/doc/qssh/PACKAGING.md", "644"],
+]
+conf-files = ["/etc/qssh/qsshd.config", "/etc/qssh/qsshd.env"]
+
+[package.metadata.deb.systemd-units]
+unit-scripts = "packaging"
+unit-name = "qsshd"
+enable = true
+start = false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,18 @@
 IMAGE := paraxiom/qssh
 TAG   := latest
 
-.PHONY: build build-hardened run stop test-connect compose-up compose-down keygen clean
+.PHONY: build build-hardened run stop test-connect compose-up compose-down keygen clean deb deb-cross
+
+# Default cross target for `make deb-cross`
+TARGET ?= x86_64-unknown-linux-gnu
+
+## Build a Debian .deb (Linux host only; needs: cargo install cargo-deb)
+deb:
+	cargo deb
+
+## Cross-build the .deb for $(TARGET) (e.g. make deb-cross TARGET=aarch64-unknown-linux-gnu)
+deb-cross:
+	cargo deb --target $(TARGET)
 
 ## Build standard image
 build:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,37 @@ qssh is part of the Paraxiom post-quantum infrastructure stack:
 
 Total: **909+ theorems** across 10 systems. All Lean 4, all zero sorries.
 
+## Install
+
+### Debian / Ubuntu (APT)
+
+```bash
+curl -fsSL https://apt.paraxiom.org/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://apt.paraxiom.org stable main" \
+  | sudo tee /etc/apt/sources.list.d/paraxiom.list
+sudo apt-get update
+sudo apt-get install qssh
+```
+
+This installs the `qssh` client, the `qsshd` daemon and the supporting tools,
+plus a systemd service for `qsshd`:
+
+```bash
+sudoedit /etc/qssh/qsshd.env     # set listen address / port
+sudo systemctl start qsshd       # generates a Falcon-512 host key on first start
+```
+
+### Standalone `.deb`
+
+Download the `.deb` from [Releases](https://github.com/Paraxiom/qssh/releases) and:
+
+```bash
+sudo apt install ./qssh_*.deb
+```
+
+Building the package yourself and the APT-repo setup are documented in
+[docs/PACKAGING.md](docs/PACKAGING.md) and [docs/APT-REPO.md](docs/APT-REPO.md).
+
 ## Releases
 
 Pre-built binaries are available under [Releases](https://github.com/Paraxiom/qssh/releases).

--- a/docs/APT-REPO.md
+++ b/docs/APT-REPO.md
@@ -1,0 +1,78 @@
+# Paraxiom APT repository (apt.paraxiom.org)
+
+Self-hosted, GPG-signed APT repository served from the OVH VPS
+(`148.113.197.101`), built with `reprepro`. The signing key lives **only on the
+VPS** — it is never copied into CI.
+
+```
+build host / CI            OVH VPS (apt.paraxiom.org)
+-----------------          --------------------------------
+cargo deb  ──► .deb ──scp──► /srv/apt/incoming/
+                           reprepro includedeb stable  (signs Release)
+                           nginx serves /srv/apt over HTTPS
+end user ◄── apt-get install qssh ◄────────────────────┘
+```
+
+## 1. One-time server setup (on the VPS)
+
+Prereqs (do these first):
+- DNS: `apt.paraxiom.org` → `148.113.197.101`
+- copy `scripts/apt-repo-bootstrap.sh` to the VPS
+
+```bash
+sudo bash apt-repo-bootstrap.sh          # installs reprepro/gnupg/nginx,
+                                         # generates the signing key,
+                                         # creates /srv/apt, configures nginx
+sudo certbot --nginx -d apt.paraxiom.org # TLS
+```
+
+The bootstrap prints the signing **key id** and exports the public key to
+`/srv/apt/paraxiom.gpg` (served at `https://apt.paraxiom.org/paraxiom.gpg`).
+
+## 2. Publish a package (from your build host)
+
+```bash
+# on a Linux build host:
+cargo deb                                  # -> target/debian/qssh_0.4.0-1_amd64.deb
+./scripts/publish-apt.sh target/debian/qssh_*.deb
+```
+
+`publish-apt.sh` scp's the `.deb` to `/srv/apt/incoming/` and runs
+`reprepro includedeb stable …` over SSH (reprepro signs the `Release` with the
+on-VPS key). Override targets with `APT_VPS`, `APT_REPO_DIR`, `APT_CODENAME`.
+
+## 3. End-user install
+
+```bash
+curl -fsSL https://apt.paraxiom.org/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://apt.paraxiom.org stable main" \
+  | sudo tee /etc/apt/sources.list.d/paraxiom.list
+sudo apt-get update
+sudo apt-get install qssh
+```
+
+## Maintenance
+
+```bash
+# list what's published
+reprepro -b /srv/apt list stable
+
+# remove a package
+reprepro -b /srv/apt remove stable qssh
+
+# the repo is plain files under /srv/apt — back that dir up (and the
+# /srv/apt-gnupg keyring, which is the irreplaceable signing key)
+```
+
+## Optional: publish from CI instead of a laptop
+
+Add an SSH **deploy key** for the VPS, store its private half as the
+`APT_DEPLOY_KEY` GitHub secret, and append a job to `.github/workflows/` that,
+after `cargo deb`, runs `scripts/publish-apt.sh`. Keep the *signing* key on the
+VPS regardless — CI only needs SSH to trigger `reprepro`.
+
+## arm64
+
+`cargo deb --target aarch64-unknown-linux-gnu` (or `make deb-cross
+TARGET=aarch64-unknown-linux-gnu`) produces an arm64 `.deb`; publish it the same
+way — the repo already lists `arm64` in `conf/distributions`.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,69 @@
+# Packaging QSSH for Linux (.deb)
+
+QSSH ships a Debian/Ubuntu package built with
+[`cargo-deb`](https://github.com/kornelski/cargo-deb) directly from the
+`[package.metadata.deb]` section of `Cargo.toml`. No hand-maintained `debian/`
+tree is required.
+
+## What's in the package
+
+| Path | Contents |
+|------|----------|
+| `/usr/bin/qssh`, `qsshd`, `qscp`, `qssh-keygen`, `qssh-passwd`, `qssh-agent`, `qssh-sign`, `qssh-add`, `qssh-node` | the 9 binaries |
+| `/etc/qssh/qsshd.config` | production config (conffile) |
+| `/etc/qssh/qsshd.env` | systemd runtime options — listen address, extra flags (conffile) |
+| `/lib/systemd/system/qsshd.service` | systemd unit for the daemon |
+| `/usr/share/doc/qssh/` | README + this file |
+
+`depends = "$auto"` lets cargo-deb compute the shared-library dependencies from
+the compiled binaries (e.g. `libssl`, `libc6`) — no manual dependency list to
+keep in sync.
+
+## Build it
+
+> **Must be built on Linux** (or for a Linux cross-target). Building on macOS
+> would produce Mach-O binaries inside the `.deb`. Use a Debian/Ubuntu host, a
+> container, or the CI workflow below.
+
+```bash
+# one-time
+cargo install cargo-deb
+
+# build (compiles --release, then packages)
+cargo deb            # or: make deb
+
+# output:
+#   target/debian/qssh_0.4.0-1_amd64.deb
+```
+
+Cross-build for amd64 from another Linux arch:
+
+```bash
+rustup target add x86_64-unknown-linux-gnu
+cargo deb --target x86_64-unknown-linux-gnu   # or: make deb-cross TARGET=x86_64-unknown-linux-gnu
+```
+
+## Install & run
+
+```bash
+sudo apt install ./qssh_0.4.0-1_amd64.deb
+
+# the service is ENABLED on install but NOT started, so you can review config first.
+sudoedit /etc/qssh/qsshd.env       # set listen address / port
+sudo systemctl start qsshd         # generates a Falcon-512 host key on first start
+systemctl status qsshd
+journalctl -u qsshd -f
+```
+
+The unit's `ExecStartPre` auto-creates `/etc/qssh/host_key` (Falcon-512) on the
+first start if it does not already exist — analogous to OpenSSH host-key
+generation. Add client public keys to `/etc/qssh/authorized_keys`.
+
+## Notes
+
+- The daemon runs as **root** (like `sshd`) because it spawns login sessions for
+  other users; `DynamicUser`/`ProtectHome` are intentionally not set.
+- `qsshd.config` and `qsshd.env` are registered as **conffiles**, so your edits
+  survive package upgrades.
+- To produce an `.rpm` as well, add `cargo-generate-rpm` and a
+  `[package.metadata.generate-rpm]` section — not configured yet.

--- a/packaging/apt/conf/distributions
+++ b/packaging/apt/conf/distributions
@@ -1,0 +1,8 @@
+Origin: Paraxiom
+Label: Paraxiom
+Suite: stable
+Codename: stable
+Architectures: amd64 arm64
+Components: main
+Description: Paraxiom APT repository (post-quantum tooling)
+SignWith: __SIGNING_KEY_ID__

--- a/packaging/apt/conf/options
+++ b/packaging/apt/conf/options
@@ -1,0 +1,2 @@
+verbose
+basedir /srv/apt

--- a/packaging/qsshd.env
+++ b/packaging/qsshd.env
@@ -1,0 +1,12 @@
+# QSSH daemon runtime options (read by the qsshd.service systemd unit).
+# Edit this file, then: systemctl restart qsshd
+
+# Address and port qsshd listens on.
+# Use 0.0.0.0:22222 to accept connections on all interfaces, or
+# 127.0.0.1:22222 to restrict to localhost.
+QSSHD_LISTEN=0.0.0.0:22222
+
+# Extra options passed verbatim to qsshd, e.g.:
+#   QSSHD_OPTS=--max-connections 200
+# (run `qsshd --help` for the full list)
+QSSHD_OPTS=

--- a/packaging/qsshd.service
+++ b/packaging/qsshd.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=QSSH - Post-Quantum Secure Shell Daemon
+Documentation=https://github.com/Paraxiom/qssh
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/qssh/qsshd.env
+
+# Generate a Falcon-512 host key on first start if one does not exist yet
+# (mirrors how OpenSSH generates host keys on install).
+ExecStartPre=/bin/sh -c 'test -f /etc/qssh/host_key || /usr/bin/qssh-keygen -t falcon512 -f /etc/qssh/host_key'
+
+ExecStart=/usr/bin/qsshd --listen ${QSSHD_LISTEN} --host-key /etc/qssh/host_key --authorized-keys /etc/qssh/authorized_keys $QSSHD_OPTS
+
+Restart=on-failure
+RestartSec=5s
+
+# Modest hardening. An SSH server must spawn login sessions, so we intentionally
+# do NOT set NoNewPrivileges / ProtectHome / DynamicUser (would break shells).
+ProtectSystem=full
+ProtectControlGroups=true
+RestrictRealtime=true
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/apt-repo-bootstrap.sh
+++ b/scripts/apt-repo-bootstrap.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# One-time bootstrap of the Paraxiom APT repository ON the OVH VPS.
+# Run as a sudo-capable user on the VPS (148.113.197.101).
+#
+#   curl -fsSL <raw-url>/apt-repo-bootstrap.sh | sudo bash
+#   (or copy it over and: sudo bash apt-repo-bootstrap.sh)
+#
+# Prereqs you must handle out-of-band:
+#   - DNS A record:  apt.paraxiom.org -> 148.113.197.101
+#   - TLS cert:      sudo certbot --nginx -d apt.paraxiom.org   (run after this)
+#
+set -euo pipefail
+
+REPO_DIR=/srv/apt
+SERVER_NAME=apt.paraxiom.org
+KEY_NAME="Paraxiom APT Signing Key"
+KEY_EMAIL="apt@paraxiom.org"
+GNUPGHOME=/srv/apt-gnupg          # dedicated keyring, root-owned
+
+echo "==> Installing reprepro, gnupg, nginx"
+apt-get update -y
+apt-get install -y reprepro gnupg nginx
+
+echo "==> Preparing GPG keyring at $GNUPGHOME"
+mkdir -p "$GNUPGHOME"; chmod 700 "$GNUPGHOME"
+export GNUPGHOME
+
+if ! gpg --list-secret-keys "$KEY_EMAIL" >/dev/null 2>&1; then
+  echo "==> Generating passphraseless signing key (for unattended reprepro signing)"
+  cat >/tmp/key.params <<EOF
+Key-Type: eddsa
+Key-Curve: ed25519
+Key-Usage: sign
+Name-Real: $KEY_NAME
+Name-Email: $KEY_EMAIL
+Expire-Date: 0
+%no-protection
+%commit
+EOF
+  gpg --batch --gen-key /tmp/key.params
+  rm -f /tmp/key.params
+fi
+
+KEYID=$(gpg --list-keys --with-colons "$KEY_EMAIL" | awk -F: '/^pub:/{print $5; exit}')
+echo "==> Signing key id: $KEYID"
+
+echo "==> Laying down repo skeleton at $REPO_DIR"
+mkdir -p "$REPO_DIR/conf" "$REPO_DIR/incoming"
+cat >"$REPO_DIR/conf/distributions" <<EOF
+Origin: Paraxiom
+Label: Paraxiom
+Suite: stable
+Codename: stable
+Architectures: amd64 arm64
+Components: main
+Description: Paraxiom APT repository (post-quantum tooling)
+SignWith: $KEYID
+EOF
+cat >"$REPO_DIR/conf/options" <<EOF
+verbose
+basedir $REPO_DIR
+EOF
+
+echo "==> Exporting public key to $REPO_DIR/paraxiom.gpg"
+gpg --export "$KEYID" > "$REPO_DIR/paraxiom.gpg"
+
+echo "==> Initialising the (empty) repo"
+reprepro -b "$REPO_DIR" export
+
+echo "==> nginx site for $SERVER_NAME"
+cat >/etc/nginx/sites-available/apt-paraxiom <<EOF
+server {
+    listen 80;
+    server_name $SERVER_NAME;
+    root $REPO_DIR;
+    autoindex on;
+    # Never serve the conf/ (distributions, signing config) or the keyring dir
+    location ~ ^/(conf|incoming)/ { deny all; }
+}
+EOF
+ln -sf /etc/nginx/sites-available/apt-paraxiom /etc/nginx/sites-enabled/apt-paraxiom
+nginx -t && systemctl reload nginx
+
+# Let reprepro write the repo as the deploy user (so CI/scp publish works).
+# Adjust 'ubuntu' if you publish as a different user.
+chown -R ubuntu:ubuntu "$REPO_DIR"
+
+cat <<EOF
+
+==> DONE.
+Next:
+  1. Point DNS:   apt.paraxiom.org -> 148.113.197.101
+  2. Get TLS:     sudo certbot --nginx -d $SERVER_NAME
+  3. Publish a package from your build host:
+        ./scripts/publish-apt.sh target/debian/qssh_*.deb
+  4. End users install with the snippet in README.md / docs/APT-REPO.md
+
+Signing key id: $KEYID
+Public key served at: https://$SERVER_NAME/paraxiom.gpg
+EOF

--- a/scripts/publish-apt.sh
+++ b/scripts/publish-apt.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Publish a built .deb to the Paraxiom APT repo on the OVH VPS.
+# reprepro (which holds the signing key) runs ON the VPS, so the key never
+# leaves the server.
+#
+# Usage:
+#   ./scripts/publish-apt.sh target/debian/qssh_0.4.0-1_amd64.deb
+#
+# Env overrides:
+#   APT_VPS=ubuntu@148.113.197.101   APT_REPO_DIR=/srv/apt   APT_CODENAME=stable
+#
+set -euo pipefail
+
+DEB="${1:?usage: publish-apt.sh <path-to-.deb>}"
+[ -f "$DEB" ] || { echo "no such file: $DEB" >&2; exit 1; }
+
+VPS="${APT_VPS:-ubuntu@148.113.197.101}"
+REPO_DIR="${APT_REPO_DIR:-/srv/apt}"
+CODENAME="${APT_CODENAME:-stable}"
+base="$(basename "$DEB")"
+
+echo "==> Uploading $base to $VPS:$REPO_DIR/incoming/"
+scp "$DEB" "$VPS:$REPO_DIR/incoming/$base"
+
+echo "==> reprepro includedeb $CODENAME ($base)"
+ssh "$VPS" "reprepro -b '$REPO_DIR' includedeb '$CODENAME' '$REPO_DIR/incoming/$base' && rm -f '$REPO_DIR/incoming/$base'"
+
+echo "==> Published. Verify:  apt-get update && apt-cache policy qssh"


### PR DESCRIPTION
Adds Linux packaging for qssh so it installs via `apt`.

## What
- **`.deb` via cargo-deb** — `[package.metadata.deb]` in Cargo.toml ships the 9 binaries to `/usr/bin`, config + env as conffiles under `/etc/qssh`, and a **systemd unit** for `qsshd` (auto-generates a Falcon-512 host key on first start, like sshd).
- **`make deb` / `make deb-cross`** targets.
- **CI** (`release-deb.yml`) builds the `.deb` on `ubuntu-latest`, uploads an artifact, and attaches it to releases on `v*` tags.
- **Self-hosted signed APT repo** (`apt.paraxiom.org`, reprepro) so `sudo apt-get install qssh` works. Signing key stays **on the VPS** — CI/laptop only push the `.deb` over SSH.
  - `scripts/apt-repo-bootstrap.sh` (one-time VPS setup)
  - `scripts/publish-apt.sh` (per-release publish)
- Docs: `docs/PACKAGING.md`, `docs/APT-REPO.md`, README install section.

## To go live
1. DNS `apt.paraxiom.org` → VPS
2. run bootstrap on VPS + certbot
3. `cargo deb` on Linux (or CI) → `publish-apt.sh`

## Note
Must be built on Linux (cargo-deb on macOS would emit Mach-O binaries). Verify on first build that `qssh-keygen -t falcon512 -f …` runs non-interactively (the unit's ExecStartPre relies on it).