### PR TITLE
docs: fix install URLs (GitHub Pages apt) + add Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,23 @@ Total: **909+ theorems** across 10 systems. All Lean 4, all zero sorries.
 
 ## Install
 
+### macOS / Linux (Homebrew)
+
+```bash
+brew tap paraxiom/tap
+brew trust paraxiom/tap     # one-time: clears Homebrew's third-party-tap check
+brew install qssh
+```
+
+Builds from source (Homebrew pulls in the Rust toolchain automatically). Works
+on macOS and on Linux via Homebrew — including ARM, where the `.deb` below is
+not yet published.
+
 ### Debian / Ubuntu (APT)
 
 ```bash
-curl -fsSL https://apt.paraxiom.org/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://apt.paraxiom.org stable main" \
+curl -fsSL https://paraxiom.github.io/apt/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://paraxiom.github.io/apt stable main" \
   | sudo tee /etc/apt/sources.list.d/paraxiom.list
 sudo apt-get update
 sudo apt-get install qssh

--- a/docs/APT-REPO.md
+++ b/docs/APT-REPO.md
@@ -1,8 +1,12 @@
-# Paraxiom APT repository (apt.paraxiom.org)
+# Paraxiom APT repository (paraxiom.github.io/apt)
 
-Self-hosted, GPG-signed APT repository served from the OVH VPS
-(`148.113.197.101`), built with `reprepro`. The signing key lives **only on the
-VPS** — it is never copied into CI.
+**The live repository is hosted on GitHub Pages at
+`https://paraxiom.github.io/apt`** (GPG-signed). End users install from there —
+see [End-user install](#3-end-user-install) below.
+
+The VPS/`reprepro` flow documented in sections 1–2 is the **legacy self-host
+option** (formerly served from the OVH VPS, now retired); kept for reference in
+case a self-hosted mirror is needed again.
 
 ```
 build host / CI            OVH VPS (apt.paraxiom.org)
@@ -44,8 +48,8 @@ on-VPS key). Override targets with `APT_VPS`, `APT_REPO_DIR`, `APT_CODENAME`.
 ## 3. End-user install
 
 ```bash
-curl -fsSL https://apt.paraxiom.org/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://apt.paraxiom.org stable main" \
+curl -fsSL https://paraxiom.github.io/apt/paraxiom.gpg | sudo tee /usr/share/keyrings/paraxiom.gpg >/dev/null
+echo "deb [signed-by=/usr/share/keyrings/paraxiom.gpg] https://paraxiom.github.io/apt stable main" \
   | sudo tee /etc/apt/sources.list.d/paraxiom.list
 sudo apt-get update
 sudo apt-get install qssh


### PR DESCRIPTION
End-user apt instructions pointed at the retired `apt.paraxiom.org` VPS. The live signed repo is GitHub Pages at https://paraxiom.github.io/apt. Updates README + docs/APT-REPO.md, marks the VPS/reprepro flow legacy, and adds the now-live Homebrew install path.