### PR TITLE
fix(kex): honor configured KexAlgorithm + default to confidential ML-KEM-1024

### DIFF
--- a/src/bin/qssh.rs
+++ b/src/bin/qssh.rs
@@ -220,7 +220,7 @@ async fn main() {
         qkd_key_path: args.qkd_key.clone(),
         qkd_ca_path: args.qkd_ca.clone(),
         pq_algorithm,
-        kex_algorithm: qssh::KexAlgorithm::default(),
+        kex_algorithm: host_config.kex_algorithm.unwrap_or_default(),
         key_rotation_interval: 3600, // 1 hour
         security_tier: SecurityTier::default(),
         quantum_native,

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct HostConfig {
     pub remote_forward: Vec<String>,
     pub dynamic_forward: Vec<String>,
     pub pq_algorithm: Option<PqAlgorithm>,
-    /// Key exchange algorithm (default: FalconSignedShares for backward compatibility)
+    /// Key exchange algorithm (default: ML-KEM-1024, FIPS 203 — confidential PQ KEX)
     pub kex_algorithm: Option<KexAlgorithm>,
     pub use_qkd: bool,
     pub qkd_endpoint: Option<String>,
@@ -263,7 +263,7 @@ impl ConfigParser {
             config.pq_algorithm = self.default_config.pq_algorithm.or(Some(PqAlgorithm::Falcon512));
         }
         if config.kex_algorithm.is_none() {
-            config.kex_algorithm = self.default_config.kex_algorithm.or(Some(KexAlgorithm::FalconSignedShares));
+            config.kex_algorithm = self.default_config.kex_algorithm.or(Some(KexAlgorithm::MlKem1024));
         }
         if config.key_rotation_interval.is_none() {
             config.key_rotation_interval = self.default_config.key_rotation_interval.or(Some(3600));
@@ -325,7 +325,7 @@ impl ConfigParser {
             qkd_key_path: host_config.qkd_key_path,
             qkd_ca_path: host_config.qkd_ca_path,
             pq_algorithm: host_config.pq_algorithm.unwrap_or(PqAlgorithm::Falcon512),
-            kex_algorithm: host_config.kex_algorithm.unwrap_or(KexAlgorithm::FalconSignedShares),
+            kex_algorithm: host_config.kex_algorithm.unwrap_or(KexAlgorithm::MlKem1024),
             key_rotation_interval: host_config.key_rotation_interval.unwrap_or(3600),
             security_tier: SecurityTier::default(),
             quantum_native: true,  // Default to quantum-native transport
@@ -468,9 +468,9 @@ Host legacy-server
         let legacy = parser.get_host_config("legacy-server");
         assert_eq!(legacy.kex_algorithm, Some(KexAlgorithm::FalconSignedShares));
 
-        // Test default (should be FalconSignedShares for backward compat)
+        // Test default (unset/unknown -> secure ML-KEM-1024, not auth-only Falcon)
         let unknown = parser.get_host_config("unknown-server");
-        assert_eq!(unknown.kex_algorithm, Some(KexAlgorithm::FalconSignedShares));
+        assert_eq!(unknown.kex_algorithm, Some(KexAlgorithm::MlKem1024));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub struct QsshConfig {
     /// Post-quantum signature algorithm to use
     pub pq_algorithm: PqAlgorithm,
 
-    /// Key exchange algorithm (default: FalconSignedShares for backward compatibility)
+    /// Key exchange algorithm (default: ML-KEM-1024, FIPS 203 — confidential PQ KEX)
     #[serde(default)]
     pub kex_algorithm: KexAlgorithm,
 
@@ -127,7 +127,7 @@ impl Default for QsshConfig {
             qkd_key_path: None,
             qkd_ca_path: None,
             pq_algorithm: PqAlgorithm::Falcon512,
-            kex_algorithm: KexAlgorithm::FalconSignedShares,
+            kex_algorithm: KexAlgorithm::MlKem1024,
             key_rotation_interval: 3600,
             security_tier: SecurityTier::default(),  // T2: Hardened PQ
             quantum_native: true,  // Default to quantum-native transport
@@ -155,12 +155,15 @@ pub enum PqAlgorithm {
 /// Key exchange algorithm for QSSH handshake
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
 pub enum KexAlgorithm {
-    /// Falcon-signed ephemeral shares (original QSSH, backward compatible)
-    #[default]
+    /// Falcon-signed ephemeral shares (original QSSH, backward compatible).
+    /// NOTE: authentication only — the session key is derived from values sent
+    /// in cleartext, so this KEX provides no confidentiality. Kept for interop;
+    /// never selected as a silent default.
     FalconSignedShares,
     /// ML-KEM-768 (FIPS 203, NIST Level 3)
     MlKem768,
     /// ML-KEM-1024 (FIPS 203, NIST Level 5)
+    #[default]
     MlKem1024,
     /// X25519 + ML-KEM-768 hybrid (requires hybrid-kex feature)
     #[cfg(feature = "hybrid-kex")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,3 +206,28 @@ pub struct QuantumCapabilities {
 pub use client::QsshClient;
 pub use client::ReconnectConfig;
 pub use server::QsshServer;
+
+#[cfg(test)]
+mod default_kex_tests {
+    use super::{KexAlgorithm, QsshConfig};
+
+    // Security regression guard: the default KEX must be a real KEM.
+    // FalconSignedShares authenticates but derives the session key from
+    // values sent in cleartext, so it provides NO confidentiality. It must
+    // never be the silent default. See PR fixing the auth-only default.
+
+    #[test]
+    fn enum_default_kex_is_confidential_mlkem1024() {
+        assert_eq!(KexAlgorithm::default(), KexAlgorithm::MlKem1024);
+        assert_ne!(KexAlgorithm::default(), KexAlgorithm::FalconSignedShares);
+    }
+
+    #[test]
+    fn qsshconfig_default_kex_is_confidential_mlkem1024() {
+        assert_eq!(QsshConfig::default().kex_algorithm, KexAlgorithm::MlKem1024);
+        assert_ne!(
+            QsshConfig::default().kex_algorithm,
+            KexAlgorithm::FalconSignedShares
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes to qssh's key exchange selection, found while validating qssh as a transport tunnel:

1. **Bug — the client silently ignored the configured KEX.** `src/bin/qssh.rs` built its `QsshConfig` with a hardcoded `KexAlgorithm::default()`, so a user's `KexAlgorithm mlkem1024` in `~/.qssh/config` had no effect. The directive was parsed and then dropped. Now the client reads the resolved per-host config.

2. **Security — the default KEX was authentication-only, not confidential.** `FalconSignedShares` derives the session key as `SHA3-256("QSSH-FALCON-v2" ‖ sorted(both key shares) ‖ client_random ‖ server_random)`, and **all of those inputs travel in cleartext** during the handshake (`KeyExchangeMessage.key_share`, `ServerHello.key_share`/`random`). A passive on-path observer recomputes the session key — so this KEX provides no confidentiality (not against a quantum adversary, and not against a classical one either). The Falcon signatures only authenticate. This default contradicts qssh's ML-KEM-1024 positioning.

   The default (unset/unknown) KEX is now **ML-KEM-1024** (FIPS 203, a real KEM, harvest-now-decrypt-later resistant), across `QsshConfig::default`, the enum's `#[default]`, config merge, and `to_qssh_config`.

## Compatibility

`FalconSignedShares` is unchanged and still available for explicit opt-in (`KexAlgorithm falcon-signed`), and the client continues to *offer* it in the negotiation list — so a new client still interoperates with an old peer that only speaks Falcon. The behavioral change is only in what gets selected when nothing is specified: secure instead of insecure.

Note: a **new client → old server** handshake will now prefer ML-KEM-1024; if a deployed server advertises ML-KEM support but its server-side path is incomplete, that pairing could fail and should fall back or be upgraded. Rolling servers first is the safe order.

## Not covered (follow-up)

`qscp` and `qssh-node` build their config without a `ConfigParser`, so they still can't honor a per-host `KexAlgorithm`. The enum default change does make them default to ML-KEM-1024. Wiring config resolution into those two binaries is a reasonable follow-up.

## Testing

- `cargo check --bins` clean.
- `cargo test --lib` KEX parsing test updated and passing (the unset/unknown case now expects ML-KEM-1024).
- Validated end-to-end: a QuantumHarmony 2-node devnet peered and finalized entirely through a `qssh -L` tunnel; with this change the handshake negotiates a real ML-KEM-1024 KEX rather than the cleartext-derived Falcon shares.
